### PR TITLE
feat: implement SSE streaming, enhanced composer, and navigation structure

### DIFF
--- a/app/__tests__/layout-test.tsx
+++ b/app/__tests__/layout-test.tsx
@@ -1,0 +1,93 @@
+import { render } from "@testing-library/react-native";
+import RootLayout from "../_layout";
+
+// Mock the SSE hook
+jest.mock("@/hooks/use-sse", () => ({
+	useSSE: jest.fn(),
+}));
+
+jest.mock("@/hooks/use-color-scheme", () => ({
+	useColorScheme: () => "light",
+}));
+
+// Mock expo-router Stack
+const mockScreenProps: Array<{
+	name: string;
+	options: Record<string, unknown>;
+}> = [];
+jest.mock("expo-router", () => ({
+	// biome-ignore lint/suspicious/noExplicitAny: mock component
+	Stack: ({ children }: any) => {
+		const { View } = require("react-native");
+		return <View testID="stack">{children}</View>;
+	},
+}));
+
+// Capture Stack.Screen props to verify navigation structure
+jest.mock("expo-router", () => {
+	const { View, Text } = require("react-native");
+	// biome-ignore lint/suspicious/noExplicitAny: mock component
+	const Stack = ({ children }: any) => <View testID="stack">{children}</View>;
+	// biome-ignore lint/suspicious/noExplicitAny: mock component
+	Stack.Screen = ({ name, options }: any) => {
+		mockScreenProps.push({ name, options });
+		return <Text testID={`screen-${name}`}>{name}</Text>;
+	};
+	return { Stack };
+});
+
+jest.mock("@react-navigation/native", () => ({
+	// biome-ignore lint/suspicious/noExplicitAny: mock component
+	ThemeProvider: ({ children }: any) => children,
+	DefaultTheme: {},
+	DarkTheme: {},
+}));
+
+jest.mock("expo-status-bar", () => ({
+	StatusBar: () => null,
+}));
+
+jest.mock("react-native-reanimated", () => ({}));
+
+describe("RootLayout", () => {
+	beforeEach(() => {
+		mockScreenProps.length = 0;
+	});
+
+	it("renders without crashing", () => {
+		render(<RootLayout />);
+	});
+
+	it("registers tab screen", () => {
+		render(<RootLayout />);
+		const tabScreen = mockScreenProps.find((s) => s.name === "(tabs)");
+		expect(tabScreen).toBeDefined();
+		expect(tabScreen?.options.headerShown).toBe(false);
+	});
+
+	it("registers session detail screen", () => {
+		render(<RootLayout />);
+		const sessionScreen = mockScreenProps.find(
+			(s) => s.name === "session/[id]",
+		);
+		expect(sessionScreen).toBeDefined();
+		expect(sessionScreen?.options.headerShown).toBe(false);
+		expect(sessionScreen?.options.animation).toBe("slide_from_right");
+	});
+
+	it("registers project detail screen", () => {
+		render(<RootLayout />);
+		const projectScreen = mockScreenProps.find(
+			(s) => s.name === "project/[id]",
+		);
+		expect(projectScreen).toBeDefined();
+		expect(projectScreen?.options.headerShown).toBe(false);
+	});
+
+	it("registers modal screen", () => {
+		render(<RootLayout />);
+		const modalScreen = mockScreenProps.find((s) => s.name === "modal");
+		expect(modalScreen).toBeDefined();
+		expect(modalScreen?.options.presentation).toBe("modal");
+	});
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,9 +5,9 @@ import {
 } from "@react-navigation/native";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import "react-native-reanimated";
-
 import { useColorScheme } from "@/hooks/use-color-scheme";
+import { useSSE } from "@/hooks/use-sse";
+import "react-native-reanimated";
 
 export const unstable_settings = {
 	anchor: "(tabs)",
@@ -16,10 +16,27 @@ export const unstable_settings = {
 export default function RootLayout() {
 	const colorScheme = useColorScheme();
 
+	// Initialize SSE connection at the app root so it persists across screens
+	useSSE();
+
 	return (
 		<ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
 			<Stack>
 				<Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+				<Stack.Screen
+					name="session/[id]"
+					options={{
+						headerShown: false,
+						animation: "slide_from_right",
+					}}
+				/>
+				<Stack.Screen
+					name="project/[id]"
+					options={{
+						headerShown: false,
+						animation: "slide_from_right",
+					}}
+				/>
 				<Stack.Screen
 					name="modal"
 					options={{ presentation: "modal", title: "Modal" }}

--- a/components/__tests__/Composer-test.tsx
+++ b/components/__tests__/Composer-test.tsx
@@ -1,31 +1,99 @@
 import { fireEvent, render } from "@testing-library/react-native";
 import { Composer } from "../composer";
 
+jest.mock("@/hooks/use-color-scheme", () => ({
+	useColorScheme: () => "light",
+}));
+
+jest.mock("@/components/ui/icon-symbol", () => ({
+	// biome-ignore lint/suspicious/noExplicitAny: mock component
+	IconSymbol: (props: any) => {
+		const { View } = require("react-native");
+		return <View testID={`icon-${props.name}`} />;
+	},
+}));
+
 describe("Composer", () => {
 	it("renders input field", () => {
 		const { getByPlaceholderText } = render(<Composer onSend={() => {}} />);
 		expect(getByPlaceholderText("Message...")).toBeTruthy();
 	});
 
-	it("calls onSend with trimmed text when send button pressed", () => {
-		const onSendMock = jest.fn();
-		const { getByPlaceholderText } = render(<Composer onSend={onSendMock} />);
-
-		const input = getByPlaceholderText("Message...");
-		fireEvent.changeText(input, "  Hello World  ");
-
-		// Note: IconSymbol doesn't have testID by default, so we might need to find by other means
-		// or just assume the printable element. for now let's find the icon by parent view logic if possible
-		// but IconSymbol renders an icon. standard practice: find by type or add testID.
-		// Let's rely on fireEvent on the element that looks like the button.
+	it("has testID on input and send button", () => {
+		const { getByTestId } = render(<Composer onSend={() => {}} />);
+		expect(getByTestId("composer-input")).toBeTruthy();
+		expect(getByTestId("composer-send-button")).toBeTruthy();
 	});
 
-	// Simplified test for now to verify rendering
+	it("calls onSend with trimmed text when send button pressed", () => {
+		const onSendMock = jest.fn();
+		const { getByTestId } = render(<Composer onSend={onSendMock} />);
+
+		const input = getByTestId("composer-input");
+		fireEvent.changeText(input, "  Hello World  ");
+		fireEvent.press(getByTestId("composer-send-button"));
+
+		expect(onSendMock).toHaveBeenCalledWith("Hello World");
+	});
+
+	it("clears input after sending", () => {
+		const { getByTestId } = render(<Composer onSend={() => {}} />);
+
+		const input = getByTestId("composer-input");
+		fireEvent.changeText(input, "Hello");
+		fireEvent.press(getByTestId("composer-send-button"));
+
+		expect(input.props.value).toBe("");
+	});
+
+	it("does not call onSend when text is empty", () => {
+		const onSendMock = jest.fn();
+		const { getByTestId } = render(<Composer onSend={onSendMock} />);
+
+		fireEvent.press(getByTestId("composer-send-button"));
+
+		expect(onSendMock).not.toHaveBeenCalled();
+	});
+
+	it("does not call onSend when text is whitespace only", () => {
+		const onSendMock = jest.fn();
+		const { getByTestId } = render(<Composer onSend={onSendMock} />);
+
+		fireEvent.changeText(getByTestId("composer-input"), "   ");
+		fireEvent.press(getByTestId("composer-send-button"));
+
+		expect(onSendMock).not.toHaveBeenCalled();
+	});
+
 	it("disables input when disabled prop is true", () => {
-		const { getByPlaceholderText } = render(
+		const { getByTestId } = render(
 			<Composer onSend={() => {}} disabled={true} />,
 		);
-		const input = getByPlaceholderText("Message...");
+		const input = getByTestId("composer-input");
 		expect(input.props.editable).toBe(false);
+	});
+
+	it("does not call onSend when disabled", () => {
+		const onSendMock = jest.fn();
+		const { getByTestId } = render(
+			<Composer onSend={onSendMock} disabled={true} />,
+		);
+
+		fireEvent.changeText(getByTestId("composer-input"), "Hello");
+		fireEvent.press(getByTestId("composer-send-button"));
+
+		expect(onSendMock).not.toHaveBeenCalled();
+	});
+
+	it("has returnKeyType set to send", () => {
+		const { getByTestId } = render(<Composer onSend={() => {}} />);
+		expect(getByTestId("composer-input").props.returnKeyType).toBe("send");
+	});
+
+	it("send button has accessibility label", () => {
+		const { getByTestId } = render(<Composer onSend={() => {}} />);
+		expect(getByTestId("composer-send-button").props.accessibilityLabel).toBe(
+			"Send message",
+		);
 	});
 });

--- a/components/composer.tsx
+++ b/components/composer.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { StyleSheet, TextInput, View } from "react-native";
+import { Pressable, StyleSheet, TextInput } from "react-native";
 import { ThemedView } from "@/components/themed-view";
 import { IconSymbol } from "@/components/ui/icon-symbol";
 import { Colors } from "@/constants/theme";
@@ -14,9 +14,10 @@ export function Composer({ onSend, disabled }: ComposerProps) {
 	const [text, setText] = useState("");
 	const colorScheme = useColorScheme() ?? "light";
 	const iconColor = Colors[colorScheme].tint;
+	const canSend = text.trim().length > 0 && !disabled;
 
 	const handleSend = () => {
-		if (text.trim() && !disabled) {
+		if (canSend) {
 			onSend(text.trim());
 			setText("");
 		}
@@ -25,6 +26,7 @@ export function Composer({ onSend, disabled }: ComposerProps) {
 	return (
 		<ThemedView style={styles.container}>
 			<TextInput
+				testID="composer-input"
 				style={[
 					styles.input,
 					{
@@ -39,16 +41,28 @@ export function Composer({ onSend, disabled }: ComposerProps) {
 				multiline
 				maxLength={2000}
 				editable={!disabled}
+				returnKeyType="send"
+				blurOnSubmit={false}
+				onSubmitEditing={handleSend}
 			/>
-			<View style={styles.sendButton}>
+			<Pressable
+				testID="composer-send-button"
+				onPress={handleSend}
+				disabled={!canSend}
+				style={({ pressed }) => [
+					styles.sendButton,
+					{ opacity: pressed && canSend ? 0.7 : 1 },
+				]}
+				accessibilityLabel="Send message"
+				accessibilityRole="button"
+			>
 				<IconSymbol
 					name="paperplane.fill"
 					size={24}
-					color={!text.trim() || disabled ? "#8E8E93" : iconColor}
-					onPress={handleSend}
-					style={{ opacity: !text.trim() || disabled ? 0.5 : 1 }}
+					color={canSend ? iconColor : "#8E8E93"}
+					style={{ opacity: canSend ? 1 : 0.5 }}
 				/>
-			</View>
+			</Pressable>
 		</ThemedView>
 	);
 }
@@ -75,6 +89,7 @@ const styles = StyleSheet.create({
 	},
 	sendButton: {
 		height: 36,
+		width: 36,
 		justifyContent: "center",
 		alignItems: "center",
 		marginBottom: 0,

--- a/hooks/__tests__/use-sse-test.ts
+++ b/hooks/__tests__/use-sse-test.ts
@@ -1,0 +1,175 @@
+import { renderHook } from "@testing-library/react-native";
+import { useSSE } from "../use-sse";
+
+// Mock the stores
+const mockConnectionState = { status: "disconnected" as string };
+jest.mock("@/app/store/connection", () => ({
+	useConnectionStore: (selector: (s: typeof mockConnectionState) => unknown) =>
+		selector(mockConnectionState),
+}));
+
+const mockOnMessageCreated = jest.fn();
+const mockOnMessageUpdated = jest.fn();
+const mockOnMessagePartDelta = jest.fn();
+const mockOnMessagePartUpdated = jest.fn();
+const mockOnSessionStatus = jest.fn();
+jest.mock("@/app/store/session", () => ({
+	useSessionStore: () => ({
+		onMessageCreated: mockOnMessageCreated,
+		onMessageUpdated: mockOnMessageUpdated,
+		onMessagePartDelta: mockOnMessagePartDelta,
+		onMessagePartUpdated: mockOnMessagePartUpdated,
+		onSessionStatus: mockOnSessionStatus,
+	}),
+}));
+
+// Mock the API
+const mockClose = jest.fn();
+const mockAddEventListener = jest.fn();
+const mockConnectToEvents = jest.fn().mockResolvedValue({
+	close: mockClose,
+	addEventListener: mockAddEventListener,
+});
+jest.mock("@/app/api/client", () => ({
+	Api: { connectToEvents: () => mockConnectToEvents() },
+}));
+
+describe("useSSE", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockConnectionState.status = "disconnected";
+	});
+
+	it("does not connect when disconnected", () => {
+		mockConnectionState.status = "disconnected";
+		renderHook(() => useSSE());
+		expect(mockConnectToEvents).not.toHaveBeenCalled();
+	});
+
+	it("connects when status is connected", async () => {
+		mockConnectionState.status = "connected";
+		renderHook(() => useSSE());
+		// Wait for async connect
+		await new Promise((r) => setTimeout(r, 50));
+		expect(mockConnectToEvents).toHaveBeenCalledTimes(1);
+	});
+
+	it("registers event listeners on connect", async () => {
+		mockConnectionState.status = "connected";
+		renderHook(() => useSSE());
+		await new Promise((r) => setTimeout(r, 50));
+		// Should register listeners for various event types
+		expect(mockAddEventListener).toHaveBeenCalled();
+		const eventNames = mockAddEventListener.mock.calls.map(
+			(call: unknown[]) => call[0],
+		);
+		expect(eventNames).toContain("message");
+		expect(eventNames).toContain("message.part.delta");
+		expect(eventNames).toContain("session.status");
+		expect(eventNames).toContain("error");
+	});
+
+	it("cleans up EventSource on unmount", async () => {
+		mockConnectionState.status = "connected";
+		const { unmount } = renderHook(() => useSSE());
+		await new Promise((r) => setTimeout(r, 50));
+		unmount();
+		expect(mockClose).toHaveBeenCalled();
+	});
+
+	it("dispatches message.part.delta events to store", async () => {
+		mockConnectionState.status = "connected";
+		renderHook(() => useSSE());
+		await new Promise((r) => setTimeout(r, 50));
+
+		// Find the "message" listener callback
+		const messageCall = mockAddEventListener.mock.calls.find(
+			(call: unknown[]) => call[0] === "message",
+		);
+		expect(messageCall).toBeDefined();
+		const handler = messageCall[1];
+
+		// Dispatch a delta event
+		handler({
+			data: JSON.stringify({
+				type: "message.part.delta",
+				properties: {
+					sessionID: "s1",
+					messageID: "m1",
+					partID: "p1",
+					delta: "hello",
+				},
+			}),
+		});
+
+		expect(mockOnMessagePartDelta).toHaveBeenCalledWith(
+			"s1",
+			"m1",
+			"p1",
+			"hello",
+		);
+	});
+
+	it("dispatches session.status events to store", async () => {
+		mockConnectionState.status = "connected";
+		renderHook(() => useSSE());
+		await new Promise((r) => setTimeout(r, 50));
+
+		const messageCall = mockAddEventListener.mock.calls.find(
+			(call: unknown[]) => call[0] === "message",
+		);
+		const handler = messageCall[1];
+
+		handler({
+			data: JSON.stringify({
+				type: "session.status",
+				properties: {
+					sessionID: "s1",
+					status: { status: "completed" },
+				},
+			}),
+		});
+
+		expect(mockOnSessionStatus).toHaveBeenCalledWith("s1", {
+			status: "completed",
+		});
+	});
+
+	it("ignores malformed event data", async () => {
+		mockConnectionState.status = "connected";
+		renderHook(() => useSSE());
+		await new Promise((r) => setTimeout(r, 50));
+
+		const messageCall = mockAddEventListener.mock.calls.find(
+			(call: unknown[]) => call[0] === "message",
+		);
+		const handler = messageCall[1];
+
+		// Should not throw
+		handler({ data: "not json" });
+		handler({ data: null });
+		handler({});
+	});
+
+	it("ignores heartbeat events", async () => {
+		mockConnectionState.status = "connected";
+		renderHook(() => useSSE());
+		await new Promise((r) => setTimeout(r, 50));
+
+		const messageCall = mockAddEventListener.mock.calls.find(
+			(call: unknown[]) => call[0] === "message",
+		);
+		const handler = messageCall[1];
+
+		handler({
+			data: JSON.stringify({
+				type: "server.heartbeat",
+				properties: {},
+			}),
+		});
+
+		// No handlers should be called
+		expect(mockOnMessageCreated).not.toHaveBeenCalled();
+		expect(mockOnMessagePartDelta).not.toHaveBeenCalled();
+	});
+});

--- a/hooks/use-sse.ts
+++ b/hooks/use-sse.ts
@@ -1,0 +1,188 @@
+import { useEffect, useRef } from "react";
+import type EventSource from "react-native-sse";
+import { Api } from "@/app/api/client";
+import type { GlobalEvent, Message, MessagePart } from "@/app/api/types";
+import { useConnectionStore } from "@/app/store/connection";
+import { useSessionStore } from "@/app/store/session";
+
+type SSEEventNames =
+	| "message.created"
+	| "message.updated"
+	| "message.part.delta"
+	| "message.part.updated"
+	| "session.status";
+
+/**
+ * Hook that manages the SSE connection lifecycle.
+ * Connects when the connection status is "connected" and
+ * dispatches events to the session store.
+ */
+export function useSSE() {
+	const esRef = useRef<EventSource<SSEEventNames> | null>(null);
+	const status = useConnectionStore((s) => s.status);
+	const {
+		onMessageCreated,
+		onMessageUpdated,
+		onMessagePartDelta,
+		onMessagePartUpdated,
+		onSessionStatus,
+	} = useSessionStore();
+
+	useEffect(() => {
+		if (status !== "connected") {
+			// Clean up if disconnected
+			if (esRef.current) {
+				esRef.current.close();
+				esRef.current = null;
+			}
+			return;
+		}
+
+		let cancelled = false;
+
+		const connect = async () => {
+			try {
+				const es = (await Api.connectToEvents()) as EventSource<SSEEventNames>;
+				if (cancelled) {
+					es.close();
+					return;
+				}
+				esRef.current = es;
+
+				// Listen for all event types by using the "message" event
+				// react-native-sse dispatches named events based on the SSE event field
+				es.addEventListener("message", (event) => {
+					if (!event.data) return;
+					try {
+						const parsed = JSON.parse(event.data) as GlobalEvent;
+						handleEvent(parsed);
+					} catch {
+						// Ignore malformed events
+					}
+				});
+
+				// Also listen for specific named events that the server may send
+				es.addEventListener("message.created", (event) => {
+					if (!event.data) return;
+					try {
+						const data = JSON.parse(event.data) as {
+							sessionID: string;
+							message: Message;
+						};
+						onMessageCreated(data.sessionID, data.message);
+					} catch {
+						// Ignore
+					}
+				});
+
+				es.addEventListener("message.updated", (event) => {
+					if (!event.data) return;
+					try {
+						const data = JSON.parse(event.data) as {
+							sessionID: string;
+							message: Message;
+						};
+						onMessageUpdated(data.sessionID, data.message);
+					} catch {
+						// Ignore
+					}
+				});
+
+				es.addEventListener("message.part.delta", (event) => {
+					if (!event.data) return;
+					try {
+						const data = JSON.parse(event.data) as {
+							sessionID: string;
+							messageID: string;
+							partID: string;
+							delta: string;
+						};
+						onMessagePartDelta(
+							data.sessionID,
+							data.messageID,
+							data.partID,
+							data.delta,
+						);
+					} catch {
+						// Ignore
+					}
+				});
+
+				es.addEventListener("message.part.updated", (event) => {
+					if (!event.data) return;
+					try {
+						const data = JSON.parse(event.data) as { part: MessagePart };
+						onMessagePartUpdated(data.part.sessionID, data.part);
+					} catch {
+						// Ignore
+					}
+				});
+
+				es.addEventListener("session.status", (event) => {
+					if (!event.data) return;
+					try {
+						const data = JSON.parse(event.data) as {
+							sessionID: string;
+							status: { status: "active" | "idle" | "completed" | "error" };
+						};
+						onSessionStatus(data.sessionID, data.status);
+					} catch {
+						// Ignore
+					}
+				});
+
+				es.addEventListener("error", () => {
+					// The EventSource will auto-reconnect by default
+					// We don't need to change connection status here as this is
+					// the SSE stream, not the HTTP connection health
+				});
+			} catch {
+				// Failed to connect — SSE is best-effort, don't crash
+				console.warn("Failed to connect to SSE events");
+			}
+		};
+
+		const handleEvent = (event: GlobalEvent) => {
+			switch (event.type) {
+				case "message.part.delta":
+					onMessagePartDelta(
+						event.properties.sessionID,
+						event.properties.messageID,
+						event.properties.partID,
+						event.properties.delta,
+					);
+					break;
+				case "message.part.updated":
+					onMessagePartUpdated(
+						event.properties.part.sessionID,
+						event.properties.part,
+					);
+					break;
+				case "session.status":
+					onSessionStatus(event.properties.sessionID, event.properties.status);
+					break;
+				case "server.connected":
+				case "server.heartbeat":
+					// No action needed
+					break;
+			}
+		};
+
+		connect();
+
+		return () => {
+			cancelled = true;
+			if (esRef.current) {
+				esRef.current.close();
+				esRef.current = null;
+			}
+		};
+	}, [
+		status,
+		onMessageCreated,
+		onMessageUpdated,
+		onMessagePartDelta,
+		onMessagePartUpdated,
+		onSessionStatus,
+	]);
+}


### PR DESCRIPTION
## Summary

Implements three issues simultaneously:

### Issue #10: Real-time message streaming via SSE
- New `useSSE` hook that connects to the OpenCode SSE event stream
- Dispatches `message.part.delta`, `message.part.updated`, `session.status`, `message.created`, and `message.updated` events to the session store
- Auto-connects when connection status is 'connected', cleans up on disconnect
- Wired at root layout level so SSE persists across all screens

### Issue #11: Message input and prompt submission
- Enhanced `Composer` component with `Pressable` send button (replacing bare icon tap)
- Added `testID`s for input and send button
- Added `returnKeyType='send'` and `onSubmitEditing` handler
- Added `accessibilityLabel` and `accessibilityRole` for a11y
- Comprehensive tests covering send flow, disabled state, empty guards

### Issue #13: App navigation structure
- Registered `session/[id]` and `project/[id]` as explicit Stack screens in root layout
- Added `slide_from_right` animation for detail screens
- Tests verifying all navigation screens are registered correctly

### Testing
- 141 total tests, all passing
- New test files: `use-sse-test.ts`, `Composer-test.tsx`, `layout-test.tsx`

Closes #10, closes #11, closes #13